### PR TITLE
feat: added postgres as separate container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,8 @@ FROM rust:1.80.1-bullseye
 RUN apt update && apt upgrade -y
 RUN apt update --fix-missing && apt install -y sudo wget curl vim git build-essential
 
+RUN apt install -y iputils-ping postgresql-client
+
 # Add custom user "dev" with sudo permissions
 RUN useradd dev -u 1000 -m -s /bin/bash && \
 	echo "dev ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,18 @@
 {
     "name": "hackrschat-dev",
 
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    // "build": {
+    //     "dockerfile": "Dockerfile"
+        
+    // },
 
     
+    
+    
+    "dockerComposeFile": "docker-compose.yaml",
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  devcontainer:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    network_mode: service:db
+    command: sleep infinity
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
So the easiest way to use postgres db for this project is to have it as a separate docker container _outside_ of our dev-container this can  be done with docker-compose which essentially allows you to run multiple containers and connect them with a network. so now inside of our dev-container we can develop the server which can connect to a postgres database under the hostname "db", try `ping db`. Also installed psql so you run this to open a cli for the db `psql --host=db --username=postgres`