### PR TITLE
Implement JSON protocol with persistent connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,42 +327,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -427,7 +395,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-channel",
  "crossterm",
- "cursive_core 0.4.6",
+ "cursive_core",
  "lazy_static",
  "libc",
  "log",
@@ -437,48 +405,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cursive-async-view"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192c058a725c80d9759b3e8957d6ee9e169a0b46c9f11216ec8c8d7990644761"
-dependencies = [
- "crossbeam",
- "cursive_core 0.3.7",
- "doc-comment",
- "interpolation",
- "lazy_static",
- "log",
- "num",
- "send_wrapper",
-]
-
-[[package]]
 name = "cursive-macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7ac0eb0cede3dfdfebf4d5f22354e05a730b79c25fd03481fc69fcfba0a73e"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "cursive_core"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db3b58161228d0dcb45c7968c5e74c3f03ad39e8983e58ad7d57061aa2cd94d"
-dependencies = [
- "ahash",
- "crossbeam-channel",
- "enum-map",
- "enumset",
- "lazy_static",
- "log",
- "num",
- "owning_ref",
- "time",
- "unicode-segmentation",
- "unicode-width",
- "xi-unicode",
 ]
 
 [[package]]
@@ -570,12 +502,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
@@ -825,12 +751,8 @@ name = "hackrschat-client"
 version = "0.1.0"
 dependencies = [
  "cursive",
- "cursive-async-view",
  "hackrschat-common",
- "serde",
  "serde_json",
- "time",
- "tokio",
 ]
 
 [[package]]
@@ -840,7 +762,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "time",
 ]
 
 [[package]]
@@ -979,12 +900,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "interpolation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7357d2bbc5ee92f8e899ab645233e43d21407573cceb37fed8bc3dede2c02"
 
 [[package]]
 name = "itertools"
@@ -1154,21 +1069,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -1230,7 +1134,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1268,15 +1171,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "parking"
@@ -1620,12 +1514,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "send_wrapper"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
@@ -1981,12 +1869,6 @@ dependencies = [
  "tracing",
  "url",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 # These will be the same for both workspace members
 [workspace.package]
-rust-version = "1.93"
+rust-version = "1.86"
 edition = "2021"
 version = "0.1.0"
 authors = ["Arc891 <[info@arc8.dev]>", "Max Gallup <[maxgallup@pm.me]>"]

--- a/hackrschat-client/Cargo.toml
+++ b/hackrschat-client/Cargo.toml
@@ -12,17 +12,4 @@ repository.workspace = true
 [dependencies]
 hackrschat-common = { path = "../hackrschat-common" }
 cursive = "0.21"
-cursive-async-view = "0.6.0"
-time = { version = "0.3.36", features = ["serde"] }
-tokio = { version = "1.39.3", features = [
-  # "full",
-  "io-util",
-  "macros",
-  "net",
-  "rt",
-  "rt-multi-thread",
-  "sync",
-] }
-serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0"
-

--- a/hackrschat-client/src/connection.rs
+++ b/hackrschat-client/src/connection.rs
@@ -1,0 +1,126 @@
+use std::io::{self, BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::sync::mpsc;
+use std::thread;
+
+use hackrschat_common::codec;
+use hackrschat_common::protocol::{Request, Response};
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum ConnectionError {
+    Io(io::Error),
+    Codec(serde_json::Error),
+    Disconnected,
+}
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectionError::Io(e) => write!(f, "I/O error: {}", e),
+            ConnectionError::Codec(e) => write!(f, "Codec error: {}", e),
+            ConnectionError::Disconnected => write!(f, "Disconnected from server"),
+        }
+    }
+}
+
+pub struct ServerConnection {
+    req_tx: mpsc::Sender<Request>,
+    resp_rx: mpsc::Receiver<Response>,
+    // push_rx will be used in the messaging phase for server-push messages
+    _push_rx: mpsc::Receiver<Response>,
+}
+
+impl ServerConnection {
+    pub fn connect(addr: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(addr)?;
+        let read_stream = stream.try_clone()?;
+
+        let (req_tx, req_rx) = mpsc::channel::<Request>();
+        let (resp_tx, resp_rx) = mpsc::channel::<Response>();
+        // push_tx/push_rx: plumbing for future server-push messages.
+        // Sender is dropped here (unused until messaging phase); receiver is stored as placeholder.
+        let (_push_tx, push_rx) = mpsc::channel::<Response>();
+
+        // Writer thread: receives Requests from the main thread and writes them to the socket.
+        let mut write_stream = stream;
+        thread::spawn(move || {
+            while let Ok(request) = req_rx.recv() {
+                let encoded = match codec::encode_request(&request) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        eprintln!("Encode error: {}", e);
+                        break;
+                    }
+                };
+                if write_stream.write_all(encoded.as_bytes()).is_err() {
+                    break;
+                }
+                if write_stream.flush().is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Reader thread: reads Responses from the socket and sends them to the main thread.
+        // Currently all responses go to resp_tx. When server-push messages are added,
+        // the reader will distinguish pushed messages and route them to push_tx instead.
+        thread::spawn(move || {
+            let mut reader = BufReader::new(read_stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Err(e) => {
+                        eprintln!("Read error: {}", e);
+                        break;
+                    }
+                    Ok(_) => {}
+                }
+                let response = match codec::decode_response(line.trim()) {
+                    Ok(resp) => resp,
+                    Err(e) => {
+                        eprintln!("Decode error: {}", e);
+                        break;
+                    }
+                };
+                if resp_tx.send(response).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(Self {
+            req_tx,
+            resp_rx,
+            _push_rx: push_rx,
+        })
+    }
+
+    /// Send a request and wait for the response.
+    ///
+    /// Ordering invariant: request-response pairing relies on (1) only one thread
+    /// calling send() at a time (Cursive is single-threaded) and (2) the server
+    /// processing requests sequentially per connection. If either invariant is
+    /// violated, add request IDs to the protocol.
+    ///
+    /// One response per request, always. The server sends exactly one Response
+    /// for each Request.
+    pub fn send(&self, request: &Request) -> Result<Response, ConnectionError> {
+        self.req_tx
+            .send(request.clone())
+            .map_err(|_| ConnectionError::Disconnected)?;
+        self.resp_rx
+            .recv()
+            .map_err(|_| ConnectionError::Disconnected)
+    }
+}
+
+impl Drop for ServerConnection {
+    fn drop(&mut self) {
+        // Best-effort: send Disconnect before channels are dropped.
+        // The server handles both clean disconnect and abrupt EOF identically.
+        let _ = self.req_tx.send(Request::Disconnect);
+    }
+}

--- a/hackrschat-client/src/main.rs
+++ b/hackrschat-client/src/main.rs
@@ -1,40 +1,17 @@
-use std::{
-    io::{Read, Write},
-    net::TcpStream,
-    // time::{Instant, Duration};
-};
+mod connection;
 
 use cursive::{
-    self, 
-    align::HAlign, 
-    traits::*, 
-    view::Margins, 
-    views::*, 
-    Cursive, 
-    CursiveExt
-    // theme::ColorStyle;
-    // theme::PaletteStyle;
-    // logger::log;
-    // style::gradient::Linear;
+    self,
+    align::HAlign,
+    traits::*,
+    view::Margins,
+    views::*,
+    Cursive,
+    CursiveExt,
 };
 
-// use serde::{Serialize, Deserialize};
-
-// use tokio::{
-//   io::{
-//     AsyncReadExt,
-//     AsyncWriteExt,
-//   },
-//   // net::TcpStream,
-//   // time::Instant,
-// };
-
-// use cursive_async_view::{
-//   AsyncState, AsyncView,
-//   AsyncProgressView, AsyncProgressState
-// };
-
-use hackrschat_common::types::{UserInfo, UserStatus};
+use hackrschat_common::protocol::{Request, Response};
+use connection::ServerConnection;
 
 const T_HEIGHT: usize = 20;
 const T_WIDTH: usize = 80;
@@ -44,13 +21,20 @@ const LOGO_WIDTH: usize = 64;
 
 const ENTRY_WIDTH: usize = 15;
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    let conn = match ServerConnection::connect("localhost:8080") {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to connect to server: {}", e);
+            std::process::exit(1);
+        }
+    };
+
     cursive::logger::init();
 
     let mut siv = Cursive::default();
+    siv.set_user_data(conn);
 
-    // Read logo from assets/logo_full.txt
     let logo: &str = include_str!("../assets/logo_full.txt");
 
     let view = ResizedView::with_fixed_size(
@@ -61,6 +45,17 @@ async fn main() {
     siv.add_layer(view);
 
     siv.run();
+}
+
+fn send_request(s: &mut Cursive, req: &Request) -> Option<Response> {
+    let result = s.with_user_data(|conn: &mut ServerConnection| conn.send(req));
+    match result {
+        Some(Ok(resp)) => Some(resp),
+        _ => {
+            s.add_layer(Dialog::info("Connection to server lost."));
+            None
+        }
+    }
 }
 
 fn login_menu(s: &mut Cursive) {
@@ -87,11 +82,6 @@ fn login_menu(s: &mut Cursive) {
     .button("Quit", Cursive::quit);
 
     s.add_layer(logo_view);
-
-    // s.add_layer(Dialog::text("Please login or register.")
-    //   .title("Welcome")
-    //   .button("Login", login)
-    //   .button("Register", register));
 }
 
 fn login(s: &mut Cursive) {
@@ -121,11 +111,6 @@ fn login(s: &mut Cursive) {
     let login_view = LinearLayout::horizontal()
         .child(labels)
         .child(entries);
-
-    // let buttons = LinearLayout::horizontal()
-    //   .child(Button::new("Back", login_menu))
-    //   .child(Button::new("Submit", Cursive::quit))
-    //   .fixed_width(20);
 
     s.add_layer(
         Dialog::around(login_view)
@@ -179,33 +164,18 @@ fn register(s: &mut Cursive) {
         .button("Login", login)
         .button("Submit", submit_register);
 
-    // let async_register: AsyncView<DummyView> = AsyncView::new(s, move || {
-    //   let instant = Instant::now();
-    //   if instant.elapsed() > Duration::from_secs(1) {
-    //     return AsyncState::Available(DummyView);
-    //   } else {
-    //     return AsyncState::Pending;
-    //   }
-    // });
-
     s.add_layer(register);
 }
 
-fn check_register(username: &str, password: &str, password_confirm: &str) -> u32 {
-    let username_taken = send_db_command(&format!("check_user {}\n", username))
-        .trim()
-        .to_string()
-        .eq("true");
-    if username.len() < 1 {
-        1
-    } else if username_taken {
-        2
+fn validate_register_fields(username: &str, password: &str, password_confirm: &str) -> Result<(), &'static str> {
+    if username.is_empty() {
+        Err("Invalid username.")
+    } else if password.is_empty() {
+        Err("Invalid password.")
     } else if password != password_confirm {
-        3
-    } else if password.len() < 1 {
-        4
+        Err("Passwords do not match.")
     } else {
-        0
+        Ok(())
     }
 }
 
@@ -214,39 +184,49 @@ fn submit_register_with_arg(s: &mut Cursive, _: &str) {
 }
 
 fn submit_register(s: &mut Cursive) {
-    let username = match s.call_on_name("username", |v: &mut EditView| v.get_content().to_string())
-    {
-        Some(s) => s,
-        None => String::from(""),
-    };
-    let password = match s.call_on_name("password", |v: &mut EditView| v.get_content().to_string())
-    {
-        Some(s) => s,
-        None => String::from(""),
-    };
-    let pwd_confirm = match s.call_on_name("password_confirm", |v: &mut EditView| v.get_content().to_string())
-    {
-        Some(s) => s,
-        None => String::from(""),
-    };
+    let username = s.call_on_name("username", |v: &mut EditView| v.get_content().to_string())
+        .unwrap_or_default();
+    let password = s.call_on_name("password", |v: &mut EditView| v.get_content().to_string())
+        .unwrap_or_default();
+    let pwd_confirm = s.call_on_name("password_confirm", |v: &mut EditView| v.get_content().to_string())
+        .unwrap_or_default();
 
-    let register_status = check_register(&username, &password, &pwd_confirm);
-    if register_status > 0 {
-        s.add_layer(Dialog::info(match register_status {
-            1 => "Invalid username.",
-            2 => "Username is taken.",
-            3 => "Passwords do not match.",
-            4 => "Invalid password.",
-            0 | 5..=u32::MAX => "Unknown error.",
-        }));
+    if let Err(msg) = validate_register_fields(&username, &password, &pwd_confirm) {
+        s.add_layer(Dialog::info(msg));
         return;
     }
 
-    main_menu(s);
+    let resp = send_request(s, &Request::CheckUser { username: username.clone() });
+    match resp {
+        Some(Response::UserExists { exists: true }) => {
+            s.add_layer(Dialog::info("Username is taken."));
+            return;
+        }
+        Some(Response::UserExists { exists: false }) => {
+            // Username available — proceed with registration stub
+            let resp = send_request(s, &Request::Register { username, password });
+            match resp {
+                Some(Response::RegisterSuccess) => {
+                    main_menu(s);
+                    return;
+                }
+                Some(Response::Error { message, .. }) => {
+                    s.add_layer(Dialog::info(message));
+                    return;
+                }
+                _ => return,
+            }
+        }
+        Some(Response::Error { message, .. }) => {
+            s.add_layer(Dialog::info(message));
+            return;
+        }
+        _ => return,
+    }
 }
 
 fn check_login(username: &str, password: &str) -> bool {
-    return username != "" && password != "";
+    !username.is_empty() && !password.is_empty()
 }
 
 fn submit_login_with_arg(s: &mut Cursive, _: &str) {
@@ -254,18 +234,12 @@ fn submit_login_with_arg(s: &mut Cursive, _: &str) {
 }
 
 fn submit_login(s: &mut Cursive) {
-    let username = match s.call_on_name("username", |v: &mut EditView| v.get_content().to_string())
-    {
-        Some(s) => s,
-        None => String::from(""),
-    };
-    let password = match s.call_on_name("password", |v: &mut EditView| v.get_content().to_string())
-    {
-        Some(s) => s,
-        None => String::from(""),
-    };
+    let username = s.call_on_name("username", |v: &mut EditView| v.get_content().to_string())
+        .unwrap_or_default();
+    let password = s.call_on_name("password", |v: &mut EditView| v.get_content().to_string())
+        .unwrap_or_default();
 
-    if check_login(&username, &password) == false {
+    if !check_login(&username, &password) {
         s.add_layer(Dialog::info("Invalid username or password."));
         return;
     }
@@ -295,19 +269,18 @@ fn main_menu(s: &mut Cursive) {
                 .child(terminal_prefix)
                 .child(terminal_input),
         );
-    
-        
-    let users = db_command_with_ret_vec("get_users\n").into_iter().map(|u| (u.username.clone(), u.display_info())).collect::<Vec<(String, String)>>();
-        
-    // let _chats = vec![
-    //     ("Chat 1".to_string(), "Chat 1 description".to_string()),
-    //     ("Chat 2".to_string(), "Chat 2 description".to_string()),
-    //     ("Chat 3".to_string(), "Chat 3 description".to_string()),
-    // ];
+
+    let users = match send_request(s, &Request::GetUsers) {
+        Some(Response::UserList(list)) => list
+            .into_iter()
+            .map(|u| (u.username.clone(), u.display_info()))
+            .collect::<Vec<_>>(),
+        _ => Vec::new(),
+    };
+
     let select = SelectView::new()
-        .with_all(std::iter::repeat(users).take(1).flatten())
-        //.on_submit(|s, item: &str| s.add_layer(Dialog::info(format!("Selected: {}", item))))
-        .on_submit(|s, item: &String| chat(s, &item))
+        .with_all(users)
+        .on_submit(|s, item: &String| chat(s, item))
         .with_name("chats");
 
     let horizontal_line = std::iter::repeat(String::from("|\n"))
@@ -332,7 +305,6 @@ fn chat(s: &mut Cursive, chat_title: &str) {
     s.pop_layer();
     let chat_input = EditView::new()
         .filler(" ")
-        // .style(ColorStyle::tertiary())
         .on_submit(chat_message)
         .with_name("input")
         .fixed_width(T_WIDTH);
@@ -363,7 +335,7 @@ fn chat(s: &mut Cursive, chat_title: &str) {
 }
 
 fn chat_message(s: &mut Cursive, message: &str) {
-    if message.starts_with("!") {
+    if message.starts_with('!') {
         terminal_command(s, &message[1..]);
         return;
     }
@@ -373,18 +345,18 @@ fn chat_message(s: &mut Cursive, message: &str) {
     });
 
     s.call_on_name("output", |v: &mut TextView| {
-        if message != "" {
+        if !message.is_empty() {
             v.append(format!("{}\n", message));
         }
     });
 }
 
 fn terminal_command(s: &mut Cursive, command: &str) {
-    let output = match command {
-        "h" | "help" => "Available commands: [h]elp, [q]uit, [l]ist, [cl]ear, join, create",
+    let output: String = match command {
+        "h" | "help" => "Available commands: [h]elp, [q]uit, [l]ist, [cl]ear, join, create".to_string(),
         "q" | "quit" => {
             s.quit();
-            ""
+            String::new()
         }
         "l" | "list" => {
             match s.call_on_name("chats", |v: &mut SelectView<String>| {
@@ -392,56 +364,54 @@ fn terminal_command(s: &mut Cursive, command: &str) {
                     .map(|(s, _)| String::from(s))
                     .collect::<Vec<String>>()
             }) {
-                Some(c) => &format!(
+                Some(c) => format!(
                     "Available chats: {}",
                     c.iter()
                         .map(|s| s.as_str())
                         .collect::<Vec<&str>>()
                         .join(", ")
                 ),
-                None => "No chats available.",
+                None => "No chats available.".to_string(),
             }
         }
         "cl" | "clear" => {
             let content = match s.call_on_name("output", |v: &mut TextView| {
                 v.get_content().to_owned().into_source()
             }) {
-                // Only grab the first line of the content
-                Some(c) => format!("{}\n", c.lines().next().unwrap().to_string()),
-                None => String::from(""),
+                Some(c) => format!("{}\n", c.lines().next().unwrap()),
+                None => String::new(),
             };
             s.call_on_name("output", |v: &mut TextView| {
                 v.set_content(content);
             });
-            ""
+            String::new()
         }
-        "join" => "Please enter a chat name to join.",
+        "join" => "Please enter a chat name to join.".to_string(),
         cmd if cmd.starts_with("join ") => {
             let param = &cmd[5..];
-            if param == "" {
-                "Invalid chat name."
+            if param.is_empty() {
+                "Invalid chat name.".to_string()
             } else {
                 let chat_name = match s.call_on_name("chats", |v: &mut SelectView<String>| {
                     match v.iter().find(move |(s, _)| *s == param) {
                         Some((s, d)) => (String::from(s), d.clone()),
-                        None => ("".to_string(), "".to_string()),
+                        None => (String::new(), String::new()),
                     }
                 }) {
-                    Some((_, d)) => String::from(d),
-                    None => "".to_string(),
+                    Some((_, d)) => d,
+                    None => String::new(),
                 };
 
-                if chat_name == "" {
-                    &format!("Chat '{}' not found.", param)
+                if chat_name.is_empty() {
+                    format!("Chat '{}' not found.", param)
                 } else {
                     chat(s, chat_name.as_str());
-                    // &format!("Joining chat: {}", param)
-                    ""
+                    String::new()
                 }
             }
         }
-        "create" => "Creating chat...",
-        _ => "Unknown command. Type 'help' for a list of commands.",
+        "create" => "Creating chat...".to_string(),
+        _ => "Unknown command. Type 'help' for a list of commands.".to_string(),
     };
 
     s.call_on_name("input", |v: &mut EditView| {
@@ -449,56 +419,8 @@ fn terminal_command(s: &mut Cursive, command: &str) {
     });
 
     s.call_on_name("output", |v: &mut TextView| {
-        if output != "" {
+        if !output.is_empty() {
             v.append(format!("$ {}\n{}\n", command, output));
         }
     });
-}
-
-fn send_db_command(command: &str) -> String {
-    let mut stream = TcpStream::connect("localhost:8080").expect("Could not connect to server.");
-    let mut buffer = [0; 4096];
-    let mut response = String::new();
-
-    stream
-        .write_all(command.as_bytes())
-        .expect("Could not write to stream.");
-    let n = stream
-        .read(&mut buffer)
-        .expect("Could not read from stream.");
-    response
-        .push_str(std::str::from_utf8(&buffer[..n]).expect("Could not convert buffer to string."));
-
-    response
-}
-
-// fn db_command_with_ret(command: &str) -> User {
-//     let response = send_db_command(command);
-//     let user: Result<User, serde_json::Error> = serde_json::from_str(&response);
-//     match user {
-//         Ok(u) => u,
-//         Err(e) => {
-//             eprintln!("Error: {}", e);
-//             User::new("err".to_string(), "err".to_string(), "err".to_string(), UserStatus::Offline, None)
-//         }
-//     }
-// }
-
-fn db_command_with_ret_vec(command: &str) -> Vec<UserInfo> {
-    let response = send_db_command(command);
-    let users: Result<Vec<UserInfo>, serde_json::Error> = serde_json::from_str(&response);
-    match users {
-        Ok(u) => u,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            let err_user = UserInfo {
-                username: "err".to_string(),
-                rank: "err".to_string(),
-                last_online: "err".to_string(),
-                status: UserStatus::Offline,
-                bio: None,
-            };
-            std::iter::repeat(err_user).take(4).collect::<Vec<UserInfo>>()
-        }
-    }
 }

--- a/hackrschat-common/Cargo.toml
+++ b/hackrschat-common/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 [dependencies]
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0"
-time = { version = "0.3.36", features = ["serde"] }
 
 [dependencies.sqlx]
 version = "0.8"

--- a/hackrschat-common/src/codec.rs
+++ b/hackrschat-common/src/codec.rs
@@ -1,0 +1,21 @@
+use crate::protocol::{Request, Response};
+
+pub fn encode_request(request: &Request) -> Result<String, serde_json::Error> {
+    let mut json = serde_json::to_string(request)?;
+    json.push('\n');
+    Ok(json)
+}
+
+pub fn encode_response(response: &Response) -> Result<String, serde_json::Error> {
+    let mut json = serde_json::to_string(response)?;
+    json.push('\n');
+    Ok(json)
+}
+
+pub fn decode_request(s: &str) -> Result<Request, serde_json::Error> {
+    serde_json::from_str(s.trim())
+}
+
+pub fn decode_response(s: &str) -> Result<Response, serde_json::Error> {
+    serde_json::from_str(s.trim())
+}

--- a/hackrschat-common/src/lib.rs
+++ b/hackrschat-common/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod types;
 pub mod protocol;
+pub mod codec;

--- a/hackrschat-common/src/protocol.rs
+++ b/hackrschat-common/src/protocol.rs
@@ -1,1 +1,50 @@
-pub const PROTOCOL_VERSION: u32 = 1;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{UserInfo, UserStatus};
+
+pub const PROTOCOL_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum Request {
+    CheckUser { username: String },
+    Register { username: String, password: String },
+    Login { username: String, password: String },
+    GetUsers,
+    GetUser { username: String },
+    SendMessage { recipient: String, content: String },
+    GetMessages { peer: String },
+    SetStatus { status: UserStatus },
+    Disconnect,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum Response {
+    Ok,
+    Error { code: ErrorCode, message: String },
+    LoginSuccess { token: String },
+    RegisterSuccess,
+    UserExists { exists: bool },
+    UserInfo(UserInfo),
+    UserList(Vec<UserInfo>),
+    MessageReceived { from: String, content: String, timestamp: String },
+    MessageHistory { messages: Vec<MessageInfo> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ErrorCode {
+    InvalidCredentials,
+    UsernameTaken,
+    UserNotFound,
+    NotAuthenticated,
+    InvalidRequest,
+    InternalError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageInfo {
+    pub sender: String,
+    pub content: String,
+    pub timestamp: String,
+}

--- a/hackrschat-server/Cargo.toml
+++ b/hackrschat-server/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { version = "1.39.3", features = [
   "net",
   "rt",
   "rt-multi-thread",
-  "sync",
 ] }
 tokio-rustls = "0.26.0"
 

--- a/hackrschat-server/src/db/mod.rs
+++ b/hackrschat-server/src/db/mod.rs
@@ -3,4 +3,4 @@ pub mod user;
 
 pub use database::Database;
 pub use user::User;
-pub use hackrschat_common::types::{UserStatus, UserInfo};
+pub use hackrschat_common::types::UserStatus;

--- a/hackrschat-server/src/db/user.rs
+++ b/hackrschat-server/src/db/user.rs
@@ -12,6 +12,7 @@ pub struct User {
     pub bio: Option<String>,
 }
 
+#[allow(dead_code)]
 impl User {
     pub fn new(username: String, password_hash: String) -> Self {
         let now = time::OffsetDateTime::now_utc();

--- a/hackrschat-server/src/main.rs
+++ b/hackrschat-server/src/main.rs
@@ -1,11 +1,14 @@
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Result};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::TcpListener,
-    sync::broadcast,
 };
 mod db;
-use db::{Database, User, UserInfo};
+use db::Database;
+use hackrschat_common::{
+    codec,
+    protocol::{ErrorCode, Request, Response},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -19,58 +22,66 @@ async fn main() -> Result<()> {
         .context("Failed to bind.")?;
     println!("Listening on localhost:8080");
 
-    let (tx, _rx) = broadcast::channel(10);
-
     loop {
-        let (mut socket, addr) = listener.accept().await.context("Failed to accept.")?;
-        let tx = tx.clone();
-        let mut rx = tx.subscribe();
+        let (socket, addr) = listener.accept().await.context("Failed to accept.")?;
         let db = db.clone();
 
         tokio::spawn(async move {
             println!("Accepted connection from: {}", addr);
 
-            let (read, mut writer) = socket.split();
-
+            let (read, mut writer) = socket.into_split();
             let mut reader = BufReader::new(read);
             let mut line = String::new();
-
-            println!("Entering loop...");
+            let mut clean_disconnect = false;
 
             loop {
-                println!("Waiting for a message...");
-                tokio::select! {
-                    result = reader.read_line(&mut line) => {
-                        if result.is_err() {
-                            println!("Failed to read from socket: {:?}", result.err());
-                            break;
-                        }
-                        if result.unwrap() == 0 {
-                            break;
-                        }
-
-                        let cmd = line.trim();
-                        if cmd == "exit" { break; }
-                        let response = handle_db_requests(&db, cmd).await.context("Failed to handle db requests.")?;
-
-                        println!("Received: '{}' from {}", cmd, addr);
-
-                        tx.send((response, addr)).context("Failed to send message")?;
-                        line.clear();
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) => break,
+                    Err(e) => {
+                        eprintln!("Read error from {}: {}", addr, e);
+                        break;
                     }
-                    result = rx.recv() => {
-                        if result.is_err() { break; }
+                    Ok(_) => {}
+                }
 
-                        let (msg, _recv_addr) = result.unwrap();
-                        // if addr == recv_addr {
-                        println!("Sending: {} to {}", msg, addr);
-                        writer.write_all(&msg.as_bytes()).await.context("Failed to write buf on sock")?;
-                        // }
+                let request = match codec::decode_request(line.trim()) {
+                    Ok(req) => req,
+                    Err(e) => {
+                        let err = Response::Error {
+                            code: ErrorCode::InvalidRequest,
+                            message: e.to_string(),
+                        };
+                        if let Ok(data) = codec::encode_response(&err) {
+                            let _ = writer.write_all(data.as_bytes()).await;
+                        }
+                        continue;
                     }
+                };
+
+                if matches!(request, Request::Disconnect) {
+                    if let Ok(data) = codec::encode_response(&Response::Ok) {
+                        let _ = writer.write_all(data.as_bytes()).await;
+                    }
+                    clean_disconnect = true;
+                    break;
+                }
+
+                let response = handle_request(&db, request).await;
+                let encoded = match codec::encode_response(&response) {
+                    Ok(data) => data,
+                    Err(_) => break,
+                };
+                if writer.write_all(encoded.as_bytes()).await.is_err() {
+                    break;
                 }
             }
-            println!("Connection closed.");
-            Ok(())
+
+            if clean_disconnect {
+                println!("Client disconnected cleanly: {}", addr);
+            } else {
+                println!("Connection lost: {}", addr);
+            }
         });
     }
 
@@ -78,62 +89,59 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn handle_db_requests(db: &Database, cmd: &str) -> Result<String> {
-    let ret = match cmd {
-        "add_user" => "Please enter a user to add.\n".to_string(),
-        cmd if cmd.starts_with("add_user ") => {
-            let username = cmd[9..].to_string();
-            if username.is_empty() {
-                return Ok("Username cannot be empty.\n".to_string());
+async fn handle_request(db: &Database, request: Request) -> Response {
+    match request {
+        Request::CheckUser { username } => match db.check_user_exists(&username).await {
+            Ok(exists) => Response::UserExists { exists },
+            Err(e) => Response::Error {
+                code: ErrorCode::InternalError,
+                message: e.to_string(),
+            },
+        },
+        Request::GetUser { username } => match db.get_user_by_username(&username).await {
+            Ok(user) => Response::UserInfo(user.into_user_info()),
+            Err(e) => {
+                if matches!(e, sqlx::Error::RowNotFound) {
+                    Response::Error {
+                        code: ErrorCode::UserNotFound,
+                        message: format!("User '{}' not found", username),
+                    }
+                } else {
+                    Response::Error {
+                        code: ErrorCode::InternalError,
+                        message: e.to_string(),
+                    }
+                }
             }
-
-            let user = User::new(username, "test".to_string());
-            db.create_user(&user).await?;
-            format!("User added: {:?}\n", user)
-        }
-        "get_user" => "Please enter a username to get.\n".to_string(),
-        cmd if cmd.starts_with("get_user ") => {
-            let username = cmd[9..].to_string();
-            if username.is_empty() {
-                return Ok("Username cannot be empty.\n".to_string());
+        },
+        Request::GetUsers => match db.get_users().await {
+            Ok(users) => {
+                let user_infos = users.into_iter().map(|u| u.into_user_info()).collect();
+                Response::UserList(user_infos)
             }
-
-            if db.check_user_exists(username.as_str()).await? == false {
-                return Ok("User does not exist.\n".to_string());
-            }
-            let user = db.get_user_by_username(&username).await?;
-            let user_info = user.into_user_info();
-            format!("{}\n", serde_json::to_string(&user_info).unwrap())
-        }
-        cmd if cmd.starts_with("get_users") => {
-            if cmd.len() > 9 {
-                return Ok("Invalid command, did you mean 'get_users'?.\n".to_string());
-            }
-            let users = db.get_users().await?;
-            let users: Vec<UserInfo> = users.into_iter().map(|user| user.into_user_info()).collect();
-            format!("{}\n", serde_json::to_string(&users).unwrap())
-        }
-        "check_user" => "Please enter a username to check.\n".to_string(),
-        cmd if cmd.starts_with("check_user ") => {
-            let username = cmd[11..].to_string();
-            if username.is_empty() {
-                return Ok("Username cannot be empty.\n".to_string());
-            }
-
-            format!("{}\n", db.check_user_exists(username.as_str()).await?)
-        }
-        _ => {
-            format!("Unknown command: {}\n", cmd)
-        }
-    };
-
-    Ok(ret)
+            Err(e) => Response::Error {
+                code: ErrorCode::InternalError,
+                message: e.to_string(),
+            },
+        },
+        Request::Register { .. } => Response::RegisterSuccess, // stub — auth phase will add real registration
+        Request::Login { .. } => Response::Error {
+            code: ErrorCode::NotAuthenticated,
+            message: "Not yet implemented".to_string(),
+        },
+        Request::SendMessage { .. } | Request::GetMessages { .. } => Response::Error {
+            code: ErrorCode::NotAuthenticated,
+            message: "Not yet implemented".to_string(),
+        },
+        // Disconnect is handled in the connection loop; this arm satisfies exhaustive match
+        Request::SetStatus { .. } | Request::Disconnect => Response::Ok,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use db::UserStatus;
+    use db::{User, UserStatus};
 
     async fn setup() -> Result<Database> {
         let db_url = dotenvy::var("DATABASE_URL").unwrap();


### PR DESCRIPTION
Replace fragile text protocol with typed newline-delimited JSON.
Client maintains persistent TCP connection with threaded reader/writer.
Server removes broadcast channel leak, processes requests sequentially.

Protocol changes:
- Add Request/Response enums with serde tagged variants
- Add codec module for JSON serialization with newline framing
- Version bumped to PROTOCOL_VERSION 2

Client changes:
- New connection module with ServerConnection abstraction
- Threaded reader/writer for non-blocking I/O
- Request-response ordering via channel pairing
- Persistent connection lifecycle (connect once, send many)

Server changes:
- Per-connection request handler (no global broadcast)
- Sequential request processing with direct response routing
- Remove tokio broadcast channel and associated dependencies